### PR TITLE
Fix srt timing if subtitles run for more then 1h

### DIFF
--- a/ttml2srt.py
+++ b/ttml2srt.py
@@ -69,7 +69,7 @@ def ticks_to_ms(tickrate, ticks, scale=1):
 def ms_to_subrip(ms):
     return '{:02d}:{:02d}:{:02d},{:03d}'.format(
         int(ms / (3600 * 1000)),   # hh
-        int(ms / 60000),           # mm
+        int(ms / 60000 - (ms / (3600 * 1000) * 60)),  # mm
         int((ms % 60000) / 1000),  # ss
         int((ms % 60000) % 1000))  # ms
 


### PR DESCRIPTION
If subtitle times are > 1h the times are wrong in the srt output for all times > 1h, this fix subtracts hours from minute field.