### PR TITLE
Add support for prime video italics

### DIFF
--- a/ttml2srt.py
+++ b/ttml2srt.py
@@ -284,7 +284,7 @@ class Ttml2Srt():
                 style_attrs = self.get_tt_style_attrs(node)
                 inline_italic = style_attrs['font_style'] == 'italic'
                 assoc_italic = style_attrs['style_id'] in self.italic_style_ids
-                if inline_italic or assoc_italic:
+                if inline_italic or assoc_italic or node.parentNode.getAttribute('style') == 'AmazonDefaultStyle':
                     _styles.append('i')
 
             if node.hasChildNodes():


### PR DESCRIPTION
The application can convert the subtitles from amazon prime video but the italic tags are lost in the process.
Amazon is using plain &lt;span&gt;&lt;/span&gt; tags to indicate italics. Some example lines:
```

   <p begin="00:01:25.336" end="00:01:28.714" region="AmazonDefaultRegion" style="AmazonDefaultStyle"><span>Lugar de nacimiento de Anck-su-namun,</span><br /> <span>concubina del faraón.</span></p>
   <p begin="00:01:28.798" end="00:01:31.425" region="AmazonDefaultRegion" style="AmazonDefaultStyle"><span>Ningún otro hombre podía tocarla.</span></p>
   <p begin="00:01:54.532" end="00:01:58.536" region="AmazonDefaultRegion" style="AmazonDefaultStyle"><span>Pero por amor,</span><br /> <span>estaban dispuestos a arriesgar la vida.</span></p>
   <p begin="00:02:17.888" end="00:02:21.350" region="AmazonDefaultRegion" style="AmazonDefaultStyle">¿Qué estáis haciendo aquí?</p>
   <p begin="00:02:39.577" end="00:02:42.121" region="AmazonDefaultRegion" style="AmazonDefaultStyle">¿Quién te ha tocado?</p>

```

I made a small modification to check for AmazonDefaultStyle to let the &lt;span&gt; tag to be converted to &lt;i&gt;.

I attach a sample file.

[amazons-subs.zip](https://github.com/yuppity/ttml2srt/files/5696623/amazons-subs.zip)