### PR TITLE
frameRateMultiplier as nominator/denominator

### DIFF
--- a/tests/test01.py
+++ b/tests/test01.py
@@ -195,6 +195,10 @@ class Tester(unittest.TestCase):
                 ('Has he fainted?', (54 * 60 + 10) * 1000, 1000),
             ),
 
+            'tvp.pl.Ekspedycja-41100771.pl.xml': (
+                ('Pa, babciu!', 4761.2 * 1000, 1000),
+            ),
+
         }
 
         for ttml_file in positions.keys():

--- a/tests/ttml-documents/tvp.pl.Ekspedycja-41100771.pl.xml
+++ b/tests/ttml-documents/tvp.pl.Ekspedycja-41100771.pl.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- zpk subtitles file - Telewizja Polska S.A. - www.tvp.pl -->
+<tt xml:lang="pl-PL" xmlns="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling" xmlns:ttp="http://www.w3.org/ns/ttml#parameter" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" ttp:frameRate="25" ttp:frameRateMultiplier="1 1" ttp:timeBase="media">
+  <head>
+    <metadata/>
+    <styling>
+      <style xml:id="style.center" tts:fontFamily="Arial" tts:fontSize="120%" tts:fontStyle="normal" tts:fontWeight="normal" tts:backgroundColor="transparent" tts:color="white" tts:textOutline="black 4px" tts:textAlign="center"/>
+    </styling>
+    <layout>
+      <region xml:id="region.after" tts:displayAlign="after" tts:backgroundColor="transparent" tts:origin="10% 50%" tts:extent="80% 40%"/>
+      <region xml:id="region.after.1" tts:displayAlign="after" tts:backgroundColor="transparent" tts:origin="10% 50%" tts:extent="80% 21.45%"/>
+    </layout>
+  </head>
+  <body>
+    <div>
+      <p style="style.center" region="region.after" begin="00:00:14.000" end="00:00:16.720"><span tts:color="#FFFF51">No i jak? Jedzie?</span><br/>Już nie. Utknął!</p>
+      <p style="style.center" region="region.after" begin="01:19:21.200" end="01:19:23.000"><span tts:color="aqua">Pa, babciu!</span></p>
+      <p style="style.center" region="region.after" begin="01:22:40.440" end="01:22:44.080"/>
+    </div>
+  </body>
+</tt>

--- a/ttml2srt.py
+++ b/ttml2srt.py
@@ -44,6 +44,20 @@ class Ttml2Srt():
             if style['font_style'] == 'italic':
                 self.italic_style_ids.append(sid)
 
+    def _parse_frame_rate_multiplier(self, expression):
+        """
+        Frame rate multiplier is stored as a fraction of nominator and denominator
+        like "2 3" == 2/3 == 0.6(6)
+        https://www.w3.org/TR/2018/PR-ttml1-20181004/#parameter-attribute-frameRateMultiplier
+        """
+        two_digits_match = re.match(r"(\d+)\s+(\d+)", expression)
+        if two_digits_match:
+            first_digit = int(two_digits_match.group(1))
+            second_digit = int(two_digits_match.group(2))
+            return float(first_digit) / float(second_digit)
+        else:
+            return float(expression)
+
     def _load_ttml_doc(self, filepath):
         """Read TTML file. Extract <p> elements and various attributes.
         """
@@ -72,7 +86,7 @@ class Ttml2Srt():
                 ('tickRate', 0, lambda x: int(x)),
                 ('timeBase', 'media', lambda x: x),
                 ('clockMode', '', lambda x: x),
-                ('frameRateMultiplier', 1, lambda x: int(x)),
+                ('frameRateMultiplier', '1', self._parse_frame_rate_multiplier),
                 ('subFrameRate', 1, lambda x: int(x)),
                 ('markerMode', '', lambda x: x),
                 ('dropMode', '', lambda x: x),


### PR DESCRIPTION
according to the spec 
frameRateMultiplier
can be a "nominator denominator" = "2 3" == 2/3 == 0.6(6)
https://www.w3.org/TR/2018/PR-ttml1-20181004/#parameter-attribute-frameRateMultiplier
Changed how frameRateMultiplier works and added a few tests