### PR TITLE
Write srt file as UTF-8

### DIFF
--- a/ttml2srt.py
+++ b/ttml2srt.py
@@ -469,7 +469,7 @@ class Ttml2Srt():
         elif output == '-':
             handle = sys.stdout
         else:
-            handle = open(output, 'w')
+            handle = open(output, 'w', encoding="utf-8")
 
         try:
             for parag in self.paragraphs(generator=True):


### PR DESCRIPTION
Was getting the following error:

```
Traceback (most recent call last):
  File "ttml2srt.py", line 559, in <module>
    ttml.write2file(getattr(args, 'output-file') or '-')
  File "ttml2srt.py", line 477, in write2file
    handle.write(parag)
  File "C:\ProgramData\Anaconda3\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u266a' in position 36: character maps to <undefined>
```

Changing the output SRT file encoding to `UTF-8` fixes this issue.